### PR TITLE
Fix infinite pagination loop in gallery loading

### DIFF
--- a/frontend/src/components/CreationGallery.tsx
+++ b/frontend/src/components/CreationGallery.tsx
@@ -84,25 +84,11 @@ export function CreationGallery({ onSelectCreation }: CreationGalleryProps) {
       // Determine if we should filter to only user's creations
       const mineOnly = ownershipFilter === 'my' && !!user;
       
-      // Load all creations - start with a large limit
-      let allCreations: CreationResponse[] = [];
-      let offset = 0;
-      const limit = 100;
-      let hasMore = true;
-      
-      while (hasMore) {
-        const result = await api.listCreations(limit, offset, mineOnly);
-        allCreations = [...allCreations, ...result.creations];
-        
-        console.log(`[CreationGallery] Loaded batch: offset=${offset}, count=${result.creations.length}, total so far=${allCreations.length}, filter=${ownershipFilter}`);
-        
-        // If we got fewer than the limit, we've reached the end
-        if (result.creations.length < limit) {
-          hasMore = false;
-        } else {
-          offset += limit;
-        }
-      }
+      // Load all creations in a single call (backend returns all)
+      const result = await api.listCreations(0, 0, mineOnly);
+      const allCreations = result.creations;
+
+      console.log(`[CreationGallery] Loaded ${allCreations.length} creations, filter=${ownershipFilter}`);
       
       console.log(`[CreationGallery] Total creations loaded: ${allCreations.length}`);
       console.log('[CreationGallery] Creation IDs:', allCreations.map(c => c.id));


### PR DESCRIPTION
## Summary
- The gallery was stuck on "Loading creations..." forever due to an infinite pagination loop
- The backend returns all creations in one response (no pagination), but the frontend kept fetching batches in a `while` loop that never terminated because `result.length >= limit` was always true
- Replaced the pagination loop with a single API call

## Test plan
- [ ] Open the app and verify the gallery loads and displays creation thumbnails
- [ ] Verify "Showing X of Y creations" count is correct
- [ ] Verify filters (Succeeded, search, sort) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)